### PR TITLE
Don't use opengl context for no reason.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,6 @@ fn main() {
 
     let window = video_subsystem.window("Ray", resolution, resolution)
         .position_centered()
-        .opengl()
         .build()
         .unwrap();
 


### PR DESCRIPTION
Reduces initialization overhead for opengl